### PR TITLE
Changed NSInteger properties of the station object to NSNumber.

### DIFF
--- a/BikeCompass WatchKit Extension/InterfaceController.m
+++ b/BikeCompass WatchKit Extension/InterfaceController.m
@@ -71,7 +71,7 @@
         Station *currentStation = [StationsRepository sharedRepository].currentStation;
         
         if ([currentStation isEqual:self.lastKnownStation]) {
-            if (currentStation.numberOfBikes != self.lastKnownStation.numberOfBikes) {
+            if (currentStation.numberOfBikes.integerValue != self.lastKnownStation.numberOfBikes.integerValue) {
                 [self updateInterface];
             }
         } else {
@@ -100,7 +100,7 @@
     if (station) {
         [self.mapView setHidden:NO];
         self.stationNameLabel.text = station.name;
-        self.numberOfBikesLabel.text = [NSString stringWithFormat:@"%ld", (long)station.numberOfBikes];
+        self.numberOfBikesLabel.text = [NSString stringWithFormat:@"%ld", station.numberOfBikes.longValue];
         [self updateRingForStation:station];
         [self updateMapWithStation:station];
     } else {
@@ -116,7 +116,7 @@
     NSInteger fromValue = 1;
     NSInteger toValue = 22;
     
-    float calculatedToValue = (float)station.numberOfBikes / ((float)station.numberOfBikes + (float)station.emptySlots);
+    float calculatedToValue = station.numberOfBikes.floatValue / (station.numberOfBikes.floatValue + station.emptySlots.floatValue);
     calculatedToValue = ceil(calculatedToValue * toValue);
     
     if (calculatedToValue == 0) {
@@ -124,7 +124,7 @@
     }
     
     // Reverse the animation if the number of bikes decreased
-    if (station.numberOfBikes < self.lastKnownStation.numberOfBikes) {
+    if (station.numberOfBikes.integerValue < self.lastKnownStation.numberOfBikes.integerValue) {
         duration *= -1;
     }
     
@@ -138,7 +138,7 @@
     
     WKInterfaceMapPinColor pinColor;
     
-    if (station.numberOfBikes > 0) {
+    if (station.numberOfBikes.integerValue > 0) {
         pinColor = WKInterfaceMapPinColorGreen;
     } else {
         pinColor = WKInterfaceMapPinColorRed;

--- a/BikeCompass/CompassViewController.m
+++ b/BikeCompass/CompassViewController.m
@@ -105,7 +105,7 @@ NSString *const kCityDetectionSegue = @"ShowCityDetectionSegue";
 
 - (void)updateInformationWithStation:(Station *)station
 {
-    if ((station.numberOfBikes != [StationsRepository sharedRepository].currentStation.numberOfBikes) ||
+    if ((station.numberOfBikes.integerValue != [StationsRepository sharedRepository].currentStation.numberOfBikes.integerValue) ||
         (![station.name isEqualToString:[StationsRepository sharedRepository].currentStation.name])) {
         [SAMSoundEffect playSoundEffectNamed:@"bell"];
     }
@@ -115,7 +115,7 @@ NSString *const kCityDetectionSegue = @"ShowCityDetectionSegue";
     // Update the station name
     self.stationLabel.text = [station.name uppercaseString];
     // Update the station bicycle count
-    [self.bicyclesRemainingButton setTitle:[NSString stringWithFormat:@"%ld", (long)station.numberOfBikes] forState:UIControlStateNormal];
+    [self.bicyclesRemainingButton setTitle:[NSString stringWithFormat:@"%ld", station.numberOfBikes.longValue] forState:UIControlStateNormal];
     
     [self pointCompassToStation:station];
     [self updateDistanceToStation:[StationsRepository sharedRepository].currentStation];

--- a/BikeCompass/StationPointAnnotation.m
+++ b/BikeCompass/StationPointAnnotation.m
@@ -17,7 +17,7 @@
 
         self.coordinate = CLLocationCoordinate2DMake(station.latitude, station.longitude);
         self.title = station.name;
-        self.subtitle = [NSString stringWithFormat:NSLocalizedString(@"%ld bikes and %ld spots left", @"Message when the user selects a pin on the map"), (long)station.numberOfBikes, (long)station.emptySlots];
+        self.subtitle = [NSString stringWithFormat:NSLocalizedString(@"%ld bikes and %ld spots left", @"Message when the user selects a pin on the map"), station.numberOfBikes.longValue, station.emptySlots.longValue];
         self.station = station;
         
     };

--- a/CityBikesKit/Station.h
+++ b/CityBikesKit/Station.h
@@ -14,8 +14,8 @@
 
 @property (strong, nonatomic) NSString *id;
 @property (strong, nonatomic) NSString *name;
-@property (assign, nonatomic) NSInteger emptySlots;
-@property (assign, nonatomic) NSInteger numberOfBikes;
+@property (strong, nonatomic) NSNumber *emptySlots;
+@property (strong, nonatomic) NSNumber *numberOfBikes;
 @property (assign, nonatomic) CLLocationDegrees latitude;
 @property (assign, nonatomic) CLLocationDegrees longitude;
 @property (assign, nonatomic, readonly) BOOL hasBikes;

--- a/CityBikesKit/Station.m
+++ b/CityBikesKit/Station.m
@@ -26,7 +26,7 @@
 
 - (BOOL)hasBikes
 {
-    return self.numberOfBikes > 0;
+    return self.numberOfBikes.integerValue > 0;
 }
 
 - (BOOL)isEqual:(id)object

--- a/CityBikesKit/StationsRepository.m
+++ b/CityBikesKit/StationsRepository.m
@@ -101,7 +101,7 @@ static NSString * const CurrentStationKey = @"com.raulriera.bikecompass.currentS
 {
     stations = [stations sortedArrayUsingComparator: ^(Station *a, Station *b) {
         
-        if (a.numberOfBikes > bikes) {
+        if (a.numberOfBikes.integerValue > bikes) {
             return (NSComparisonResult)NSOrderedAscending;
         } else {
             return (NSComparisonResult)NSOrderedDescending;

--- a/Todays Widget/TodayViewController.m
+++ b/Todays Widget/TodayViewController.m
@@ -60,10 +60,10 @@
 - (void)updateWidgetWithStation:(Station *)station
 {
     self.stationNameLabel.text = station.name;
-    self.numberOfBikesLabel.text = [NSString stringWithFormat:@"%ld", (long)station.numberOfBikes];
+    self.numberOfBikesLabel.text = [NSString stringWithFormat:@"%ld", station.numberOfBikes.longValue];
     self.numberOfBikesLabel.layer.cornerRadius = 6;
     
-    if (station.numberOfBikes > 0) {
+    if (station.numberOfBikes.integerValue > 0) {
         self.numberOfBikesLabel.backgroundColor = [UIColor colorWithRed:34.0f/255.0f green:122.0f/255.0f blue:66.0f/255.0f alpha:1];
     } else {
         self.numberOfBikesLabel.backgroundColor = [UIColor colorWithRed:241.0f/255.0f green:23.0f/255.0f blue:23.0f/255.0f alpha:1];


### PR DESCRIPTION
Reason for change:

When mapping our dictionaries to our models MTLModel uses NSObject validateValue:forKey:error:
If the properties is of type NSInteger and the value is nil this will return true, it will then
attempt to setValue:forKey with the nil value and cause a crash.

Using NSNumber we protect ourselves against this.
